### PR TITLE
Tests

### DIFF
--- a/dtintegrations/data_connector/http_push.py
+++ b/dtintegrations/data_connector/http_push.py
@@ -35,7 +35,7 @@ def decode(headers: dict, body: bytes, secret: str) -> Any:
     # Do some mild secret sanitization, ensuring populated string.
     if isinstance(secret, str):
         if len(secret) == 0:
-            raise disruptive.errors.EmptyStringError(
+            raise disruptive.errors.ConfigurationError(
                 'Secret is empty string.'
             )
     else:


### PR DESCRIPTION
- Wrote more tests to cover a few exceptions.
- The `decode()` EmptyStringError replaced with ConfigurationError.