### PR TITLE
fix: support temperature events with backfill field

### DIFF
--- a/dtintegrations/data_connector/http_push.py
+++ b/dtintegrations/data_connector/http_push.py
@@ -1,5 +1,5 @@
 import jwt
-import ast
+import json
 import hashlib
 from typing import Any, Optional
 
@@ -145,7 +145,7 @@ class HttpPush(outputs.OutputBase):
             )
 
         # Convert the body bytes string into a dictionary.
-        body_dict = ast.literal_eval(body.decode('utf-8'))
+        body_dict = json.loads(body.decode('utf-8'))
 
         return dict(body_dict)
 

--- a/tests/events.py
+++ b/tests/events.py
@@ -23,6 +23,15 @@ touch = Event(
     payload={'checksum': 'f2b5dc0496437201d3cee156c233a1335603d465', 'checksum_sha256': 'afd81a16bb9c076e57f92728f284ff55831bfdf1d3c2c10b833567f521d782de', 'exp': 1644500533, 'iat': 1644496933, 'jti': 'c82gg99hga35jc2afkeg'},  # noqa
 )
 
+temperature = Event(
+    headers={
+        'X-Dt-Signature': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjaGVja3N1bSI6IjBmNzUzOTM5YTEzNzdhM2M5NGFiZDJjZmViZGMyY2I0NzU2YzNmYzMiLCJjaGVja3N1bV9zaGEyNTYiOiI1YjVmYzJlN2M3NjM3YWIzN2RiNDJiNzQ1YmY2ZjEyOWZhZTk3ODJmOTUzZWQzZGM2NDM1YzMyMTQ4ZjQxNWQ0IiwiZXhwIjoxNzE2OTgyNDQzLCJpYXQiOjE3MTY5Nzg4NDMsImp0aSI6ImNwYmc5NnQxaXNqbHIydmRvcmMwIn0.A4r91SKDW4IqYtb1eXuTQCUxM6GnouPbt94Ywd-vCpU' # noqa
+    },
+    body_str='{"event":{"eventId":"cpbg96qngr7ai7ldarrg","targetName":"projects/ccol8iuk9smqiha4e8l0/devices/emucdd6ef2eu277bo8f52vg","eventType":"temperature","data":{"temperature":{"value":27,"updateTime":"2024-05-29T10:34:03.970415Z","samples":[{"value":27,"sampleTime":"2024-05-29T10:34:03.970415Z"}],"isBackfilled":false}},"timestamp":"2024-05-29T10:34:03.970415Z"},"labels":{"name":"test temp"},"metadata":{"deviceId":"emucdd6ef2eu277bo8f52vg","projectId":"ccol8iuk9smqiha4e8l0","deviceType":"temperature","productNumber":""}}', # noqa
+    body={'event':{'eventId':'cpbg96qngr7ai7ldarrg','targetName':'projects/ccol8iuk9smqiha4e8l0/devices/emucdd6ef2eu277bo8f52vg','eventType':'temperature','data':{'temperature':{'value':27,'updateTime':'2024-05-29T10:34:03.970415Z','samples':[{'value':27,'sampleTime':'2024-05-29T10:34:03.970415Z'}],'isBackfilled':False}},'timestamp':'2024-05-29T10:34:03.970415Z'},'labels':{'name':'test temp'},'metadata':{'deviceId':'emucdd6ef2eu277bo8f52vg','projectId':'ccol8iuk9smqiha4e8l0','deviceType':'temperature','productNumber':''}}, # noqa
+    payload={'checksum': '0f753939a1377a3c94abd2cfebdc2cb4756c3fc3', 'checksum_sha256': '5b5fc2e7c7637ab37db42b745bf6f129fae9782f953ed3dc6435c32148f415d4', 'exp': 1716982443, 'iat': 1716978843, 'jti': 'cpbg96t1isjlr2vdorc0'}, # noqa
+)
+
 metadata = {
     'deviceId': 'test-device',
     'projectId': 'test-project',

--- a/tests/test_http_push.py
+++ b/tests/test_http_push.py
@@ -77,6 +77,23 @@ class TestHttpPush():
         assert isinstance(payload.event, disruptive.events.Event)
         assert payload.event.event_id == test_event.body['event']['eventId']
 
+    def test_decode_temperature(self, decode_mock):
+        # Choose an event to receive.
+        test_event = events.temperature
+
+        # Update the mock event attribute.
+        decode_mock.event = test_event
+
+        # Attempt to decode the request.
+        payload = data_connector.HttpPush.from_provider(
+            request=framework.FlaskRequestFormat(test_event),
+            provider=provider.FLASK,
+            secret='test-secret',
+        )
+
+        assert isinstance(payload.event, disruptive.events.Event)
+        assert payload.event.event_id == test_event.body['event']['eventId']
+
     def test_decode_flask_name_casing(self, decode_mock):
         # Choose an event to receive.
         test_event = events.touch
@@ -111,6 +128,23 @@ class TestHttpPush():
     def test_decode_django(self, decode_mock):
         # Choose an event to receive.
         test_event = events.touch
+
+        # Update the mock event attribute.
+        decode_mock.event = test_event
+
+        # Attempt to decode the request.
+        payload = data_connector.HttpPush.from_provider(
+            request=framework.DjangoRequestFormat(test_event),
+            provider=provider.DJANGO,
+            secret='test-secret',
+        )
+
+        assert isinstance(payload.event, disruptive.events.Event)
+        assert payload.event.event_id == test_event.body['event']['eventId']
+    
+    def test_decode_temperature(self, decode_mock):
+        # Choose an event to receive.
+        test_event = events.temperature
 
         # Update the mock event attribute.
         decode_mock.event = test_event
@@ -159,6 +193,23 @@ class TestHttpPush():
     def test_decode_gcloud(self, decode_mock):
         # Choose an event to receive.
         test_event = events.touch
+
+        # Update the mock event attribute.
+        decode_mock.event = test_event
+
+        # Attempt to decode the request.
+        payload = data_connector.HttpPush.from_provider(
+            request=framework.GcloudRequestFormat(test_event),
+            provider=provider.GCLOUD,
+            secret='test-secret',
+        )
+
+        assert isinstance(payload.event, disruptive.events.Event)
+        assert payload.event.event_id == test_event.body['event']['eventId']
+    
+    def test_decode_temperature(self, decode_mock):
+        # Choose an event to receive.
+        test_event = events.temperature
 
         # Update the mock event attribute.
         decode_mock.event = test_event
@@ -221,6 +272,23 @@ class TestHttpPush():
         assert isinstance(payload.event, disruptive.events.Event)
         assert payload.event.event_id == test_event.body['event']['eventId']
 
+    def test_decode_temperature(self, decode_mock):
+        # Choose an event to receive.
+        test_event = events.temperature
+
+        # Update the mock event attribute.
+        decode_mock.event = test_event
+
+        # Attempt to decode the request.
+        payload = data_connector.HttpPush.from_provider(
+            request=framework.lambda_request_format(test_event),
+            provider=provider.LAMBDA,
+            secret='test-secret',
+        )
+
+        assert isinstance(payload.event, disruptive.events.Event)
+        assert payload.event.event_id == test_event.body['event']['eventId']
+
     def test_decode_lambda_name_casing(self, decode_mock):
         # Choose an event to receive.
         test_event = events.touch
@@ -255,6 +323,23 @@ class TestHttpPush():
     def test_decode_azure(self, decode_mock):
         # Choose an event to receive.
         test_event = events.touch
+
+        # Update the mock event attribute.
+        decode_mock.event = test_event
+
+        # Attempt to decode the request.
+        payload = data_connector.HttpPush.from_provider(
+            request=framework.AzureRequestFormat(test_event),
+            provider=provider.AZURE,
+            secret='test-secret',
+        )
+
+        assert isinstance(payload.event, disruptive.events.Event)
+        assert payload.event.event_id == test_event.body['event']['eventId']
+    
+    def test_decode_temperature(self, decode_mock):
+        # Choose an event to receive.
+        test_event = events.temperature
 
         # Update the mock event attribute.
         decode_mock.event = test_event


### PR DESCRIPTION
The decoding using ast.literal_eval failed due to a newly introduced field in the temperature events. The boolean isBackfilled could not be decoded by ast because it needs valid python and a all lower case 'false' in json would not work. Changed to using json.loads to unmarshal the json object.